### PR TITLE
Double quotes to single quote to avoid messing up c# string

### DIFF
--- a/templates/alteration/structuremap/instructions.txt
+++ b/templates/alteration/structuremap/instructions.txt
@@ -1,7 +1,7 @@
 
 
 * StructureMap configuration is in the file %SHORT_NAME%Registry
-* StructureMap's default "IFoo is Foo" conventions are configured for this project
+* StructureMap's default 'IFoo is Foo' conventions are configured for this project
 
 The FubuMVC application is defined in the %APPLICATION_SOURCE% class.  It's unlikely that you'll
 need to customize the application bootstrapping, but %APPLICATION_SOURCE% is where that would


### PR DESCRIPTION
WIth `fubu new --app` out of the box for me the generated project fails to build due to unescaped quotes.
