### PR TITLE
Default settings of fubu new command should create an web application

### DIFF
--- a/src/Fubu/Generation/NewCommand.cs
+++ b/src/Fubu/Generation/NewCommand.cs
@@ -116,7 +116,7 @@ namespace Fubu.Generation
 
             request.AddTemplate(_rippleTemplates[input.RippleFlag]);
 
-            if (input.AppFlag)
+            if (!input.EmptyFlag)
             {
                 var projectRequest = addApplicationProject(input, request);
                 if (input.TestsFlag)

--- a/src/Fubu/Generation/NewCommandInput.cs
+++ b/src/Fubu/Generation/NewCommandInput.cs
@@ -14,8 +14,8 @@ namespace Fubu.Generation
 
         // If this is blank, use this folder as the solution name too
 
-        [Description("If chosen, fubu new will also create a single, empty FubuMVC application project with the same name")]
-        public bool AppFlag { get; set; }
+        [Description("If chosen, fubu new will only create an empty solution.")]
+        public bool EmptyFlag { get; set; }
 
         [Description("Add a testing library for the project using the default FubuTestingSupport w/ NUnit")]
         public bool TestsFlag { get; set; }

--- a/src/Fubu/Generation/QuickstartCommand.cs
+++ b/src/Fubu/Generation/QuickstartCommand.cs
@@ -14,7 +14,7 @@ namespace Fubu.Generation
                 ShortNameFlag = ShortNameFlag,
 
                 OptionsFlag = new string[]{"spark"}, // needs to get smarter here
-                AppFlag = true,
+                EmptyFlag = false,
                 TestsFlag = true
             };
         }

--- a/src/fubu.Testing/Generation/NewCommandTester.cs
+++ b/src/fubu.Testing/Generation/NewCommandTester.cs
@@ -2,7 +2,6 @@
 using Fubu.Generation;
 using FubuCore;
 using FubuCsProjFile.Templating;
-using FubuMVC.Core;
 using NUnit.Framework;
 using FubuTestingSupport;
 using System.Linq;
@@ -30,11 +29,11 @@ namespace fubu.Testing.Generation
         [Test]
         public void new_project_request_gets_the_assembly_version_alteration()
         {
-            var input = new NewCommandInput
-            {
-                SolutionName = "NewThing",
-                AppFlag = true
-            };
+	        var input = new NewCommandInput
+	        {
+		        SolutionName = "NewThing",
+		        EmptyFlag = false
+	        };
 
             var request = NewCommand.BuildTemplateRequest(input);
             request.Projects.Single().Template.ShouldContain("baseline");
@@ -43,12 +42,12 @@ namespace fubu.Testing.Generation
         [Test]
         public void supports_the_shortname_flag()
         {
-            var input = new NewCommandInput
-            {
-                SolutionName = "FubuMVC.Scenarios",
-                AppFlag = true,
-                ShortNameFlag = "Foo"
-            };
+	        var input = new NewCommandInput
+	        {
+		        SolutionName = "FubuMVC.Scenarios",
+		        EmptyFlag = false,
+		        ShortNameFlag = "Foo"
+	        };
 
             var request = NewCommand.BuildTemplateRequest(input);
 
@@ -58,11 +57,11 @@ namespace fubu.Testing.Generation
         [Test]
         public void add_no_views_home_page_if_there_are_no_views()
         {
-            var input = new NewCommandInput
-            {
-                SolutionName = "FubuMVC.Scenarios",
-                AppFlag = true,
-            };
+	        var input = new NewCommandInput
+	        {
+		        SolutionName = "FubuMVC.Scenarios",
+		        EmptyFlag = false,
+	        };
 
             var request = NewCommand.BuildTemplateRequest(input);
             request.Projects.Single().Alterations.ShouldContain("no-views");
@@ -71,12 +70,12 @@ namespace fubu.Testing.Generation
         [Test]
         public void add_spark_but_not_no_views_if_spark_option_is_requested()
         {
-            var input = new NewCommandInput
-            {
-                SolutionName = "FubuMVC.Scenarios",
-                AppFlag = true,
-                OptionsFlag = new string[]{"spark"}
-            };
+	        var input = new NewCommandInput
+	        {
+		        SolutionName = "FubuMVC.Scenarios",
+		        EmptyFlag = false,
+		        OptionsFlag = new string[] {"spark"}
+	        };
 
             var request = NewCommand.BuildTemplateRequest(input);
             request.Projects.Single().Alterations.ShouldNotContain("no-views");
@@ -116,15 +115,14 @@ namespace fubu.Testing.Generation
         }
 
         [Test]
-        public void no_project_if_app_flag_is_false()
+        public void no_project_if_empty_flag_is_true()
         {
             var input = new NewCommandInput
             {
                 SolutionName = "NewThing",
-                RippleFlag = FeedChoice.Edge
+                RippleFlag = FeedChoice.Edge,
+				EmptyFlag = true
             };
-
-            input.AppFlag.ShouldBeFalse();
 
             var request = NewCommand.BuildTemplateRequest(input);
         
@@ -180,7 +178,7 @@ namespace fubu.Testing.Generation
             var input = new NewCommandInput
             {
                 SolutionName = "NewThing",
-                AppFlag = true,
+                EmptyFlag = false,
                 TestsFlag = false
             };
 
@@ -191,12 +189,12 @@ namespace fubu.Testing.Generation
         [Test]
         public void adds_in_the_testing_request_if_app_and_tests_are_selected()
         {
-            var input = new NewCommandInput
-            {
-                SolutionName = "NewThing",
-                AppFlag = true,
-                TestsFlag = true
-            };
+	        var input = new NewCommandInput
+	        {
+		        SolutionName = "NewThing",
+		        EmptyFlag = false,
+		        TestsFlag = true
+	        };
 
             var request = NewCommand.BuildTemplateRequest(input);
             var testingRequest = request.TestingProjects.Single();
@@ -242,11 +240,11 @@ namespace fubu.Testing.Generation
         [SetUp]
         public void SetUp()
         {
-            var input = new NewCommandInput
-            {
-                SolutionName = "NewThing",
-                AppFlag = true
-            };
+	        var input = new NewCommandInput
+	        {
+		        SolutionName = "NewThing",
+		        EmptyFlag = false
+	        };
 
             var request = NewCommand.BuildTemplateRequest(input);
 


### PR DESCRIPTION
I found the default behavior of fubu new to be difficult for someone like me approaching it for the first time. Currently the default behavior of `fubu new` is to create a blank solution. I kept hearing `fubu new` is the way to go. So the first thing I did was grab the **fubu** gem and run it with no arguments. 

![fubu](http://cl.ly/image/0b3f331y2V0i/Image%202013-11-04%20at%209.26.08%20AM.png)

From this usage it seems correct to do a `fubu new` So I do that and end up with no project just a solution. 

Later on Twitter Jeremy tells me about `fubu new --app`. Great but how from the usage above is one to figure that out? Ah `fubu help new` to the rescue.

Only then do I learn that there is an optional flag to set for generating an app. IMHO the reason that people would typically need a project generator for a web framework is to generate a web project. 

This PR is proposing that the default be to create a web application and that the flag `fubu new --empty` or something similar be the optional argument that allows creation of an empty solution. 
